### PR TITLE
Added locales to footer message

### DIFF
--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -6,10 +6,10 @@ import GitVersion from './common/GitVersion.vue'
   <footer>
     <div class="footer">
       <div class="left">
-        © {{ new Date().getFullYear() }} Coded by <a
+        © {{ new Date().getFullYear() }} | {{ $t('application.footer.coded_by') }} <a
           href="http://im.daidr.me" target="_blank"
           class="dou-sc-link"
-        >daidr</a> with ❤.
+        >daidr</a> {{ $t('application.footer.with_love') }}.
       </div>
       <div class="right">
         <GitVersion />

--- a/src/locales/ar-EG.json
+++ b/src/locales/ar-EG.json
@@ -1,6 +1,10 @@
 {
   "application": {
-    "name": "أداة اختبار DualSense"
+    "name": "أداة اختبار DualSense",
+    "footer": {
+      "coded_by": "مبرمج بواسطة",
+      "with_love": "بكل ❤"
+    }
   },
   "shared": {
     "unknown": "غير معروف",

--- a/src/locales/ar-SA.json
+++ b/src/locales/ar-SA.json
@@ -1,6 +1,10 @@
 {
   "application": {
-    "name": "أداة اختبار DualSense"
+    "name": "أداة اختبار DualSense",
+    "footer": {
+      "coded_by": "مبرمج بواسطة",
+      "with_love": "بكل ❤"
+    }
   },
   "shared": {
     "unknown": "غير معروف",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1,6 +1,10 @@
 {
   "application": {
-    "name": "DualSense Tester"
+    "name": "DualSense Tester",
+    "footer": {
+      "coded_by": "Coded by",
+      "with_love": "with ❤"
+    }
   },
   "shared": {
     "unknown": "Unknown",

--- a/src/locales/fa-IR.json
+++ b/src/locales/fa-IR.json
@@ -1,6 +1,10 @@
 {
   "application": {
-    "name": "DualSense Tester"
+    "name": "DualSense Tester",
+    "footer": {
+      "coded_by": "Coded by",
+      "with_love": "with ❤"
+    }
   },
   "shared": {
     "unknown": "Unknown",

--- a/src/locales/ru-RU.json
+++ b/src/locales/ru-RU.json
@@ -1,6 +1,10 @@
 {
   "application": {
-    "name": "Тестер контроллера DualSense"
+    "name": "Тестер контроллера DualSense",
+    "footer": {
+      "coded_by": "Coded by",
+      "with_love": "with ❤"
+    }
   },
   "shared": {
     "unknown": "Неизвестно",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,6 +1,10 @@
 {
   "application": {
-    "name": "DualSense 在线测试"
+    "name": "DualSense 在线测试",
+    "footer": {
+      "coded_by": "Coded by",
+      "with_love": "with ❤"
+    }
   },
   "shared": {
     "unknown": "未知",


### PR DESCRIPTION
A very tiny suggestion to support multiple locales in the heartwarming footer so users see the message in their preferred language. 😄

Before: (ar-*)
![image](https://github.com/user-attachments/assets/6054a9ad-5227-4d57-b257-00b3dfd01534)

After: (ar-*)
![image](https://github.com/user-attachments/assets/d4c35cba-4561-4ed1-94e2-1160025e3735)
 