### PR TITLE
feat: format accelerometer

### DIFF
--- a/src/router/DualSense/views/_visualizerPanel/AccelView.vue
+++ b/src/router/DualSense/views/_visualizerPanel/AccelView.vue
@@ -2,6 +2,7 @@
 import ThreeAxisGraph from '@/components/common/ThreeAxisGraph.vue'
 import { useConnectionType, useInputReport } from '@/composables/useInjectValues'
 import { DeviceConnectionType, type ModelProps } from '@/device-based-router/shared'
+import { formatAccel } from '@/utils/format.util'
 import { computedAsync } from '@vueuse/core'
 import { computed } from 'vue'
 import { inputReportOffsetBluetooth, inputReportOffsetUSB } from '../../_utils/offset.util'
@@ -20,9 +21,9 @@ const accelInfo = computedAsync(async () => {
   const accelZ = inputReport.value.getInt16(offset.value.accelZ, true)
 
   return {
-    x: accelX,
-    y: accelY,
-    z: accelZ,
+    x: formatAccel(accelX),
+    y: formatAccel(accelY),
+    z: formatAccel(accelZ),
   }
 })
 </script>
@@ -34,7 +35,7 @@ const accelInfo = computedAsync(async () => {
         X
       </p>
       <p class="w-1/2 text-end">
-        {{ accelInfo.x }}
+        {{ accelInfo.x }} m/s²
       </p>
     </div>
     <div class="w-full flex justify-between text-[#f14c4c] font-sans">
@@ -42,7 +43,7 @@ const accelInfo = computedAsync(async () => {
         Y
       </p>
       <p class="w-1/2 text-end">
-        {{ accelInfo.y }}
+        {{ accelInfo.y }} m/s²
       </p>
     </div>
     <div class="w-full flex justify-between text-[#f9aa53] font-sans">
@@ -50,7 +51,7 @@ const accelInfo = computedAsync(async () => {
         Z
       </p>
       <p class="w-1/2 text-end">
-        {{ accelInfo.z }}
+        {{ accelInfo.z }} m/s²
       </p>
     </div>
     <ThreeAxisGraph v-if="showValue" class="h-150px w-full" :value="accelInfo" />

--- a/src/router/DualSenseEdge/views/_visualizerPanel/AccelView.vue
+++ b/src/router/DualSenseEdge/views/_visualizerPanel/AccelView.vue
@@ -2,6 +2,7 @@
 import ThreeAxisGraph from '@/components/common/ThreeAxisGraph.vue'
 import { useConnectionType, useInputReport } from '@/composables/useInjectValues'
 import { DeviceConnectionType, type ModelProps } from '@/device-based-router/shared'
+import { formatAccel } from '@/utils/format.util'
 import { computedAsync } from '@vueuse/core'
 import { computed } from 'vue'
 import { inputReportOffsetBluetooth, inputReportOffsetUSB } from '../../_utils/offset.util'
@@ -20,9 +21,9 @@ const accelInfo = computedAsync(async () => {
   const accelZ = inputReport.value.getInt16(offset.value.accelZ, true)
 
   return {
-    x: accelX,
-    y: accelY,
-    z: accelZ,
+    x: formatAccel(accelX),
+    y: formatAccel(accelY),
+    z: formatAccel(accelZ),
   }
 })
 </script>
@@ -34,7 +35,7 @@ const accelInfo = computedAsync(async () => {
         X
       </p>
       <p class="w-1/2 text-end">
-        {{ accelInfo.x }}
+        {{ accelInfo.x }} m/s²
       </p>
     </div>
     <div class="w-full flex justify-between text-[#f14c4c] font-sans">
@@ -42,7 +43,7 @@ const accelInfo = computedAsync(async () => {
         Y
       </p>
       <p class="w-1/2 text-end">
-        {{ accelInfo.y }}
+        {{ accelInfo.y }} m/s²
       </p>
     </div>
     <div class="w-full flex justify-between text-[#f9aa53] font-sans">
@@ -50,7 +51,7 @@ const accelInfo = computedAsync(async () => {
         Z
       </p>
       <p class="w-1/2 text-end">
-        {{ accelInfo.z }}
+        {{ accelInfo.z }} m/s²
       </p>
     </div>
     <ThreeAxisGraph v-if="showValue" class="h-150px w-full" :value="accelInfo" />

--- a/src/utils/format.util.ts
+++ b/src/utils/format.util.ts
@@ -45,3 +45,17 @@ export function notAllFalsy(...args: unknown[]) {
 export function bitShiftByte(value: number, shift: number) {
   return (value << shift) & 0xFF
 }
+
+export function formatAccel(value: number): number | string {
+  const ACCEL_RES_PER_G = 8192
+  const STANDARD_GRAVITY = 9.80665
+
+  const accel = (value / ACCEL_RES_PER_G) * STANDARD_GRAVITY
+
+  if (accel === 0) {
+    return accel
+  }
+  else {
+    return accel.toFixed(5)
+  }
+}


### PR DESCRIPTION
Thank you for open-sourcing this interesting project. I have formatted the algorithm for the DS5 controller's accelerometer based on [SDL v2](https://github.com/libsdl-org/SDL/tree/SDL2). The final unit of the accelerometer is `m/s²`, and the algorithm is as follows:

```c
#define ACCEL_RES_PER_G 8192.0f
#define SDL_STANDARD_GRAVITY 9.80665f
result = (result / ACCEL_RES_PER_G) * SDL_STANDARD_GRAVITY;
```

- `ACCEL_RES_PER_G`: Represents the resolution of the raw acceleration data corresponding to one gravitational acceleration g.
- `SDL_STANDARD_GRAVITY`: The standard gravitational acceleration defined as `9.80665f`, with units in `m/s²`.

Reference: 

https://github.com/libsdl-org/SDL/blob/c16b7bcb7acb35c5b91153e6cd6b0da847394a09/src/joystick/hidapi/SDL_hidapi_ps5.c#L665C47-L665C67

By the way, my project [PeaSyo](https://github.com/Geocld/PeaSyo) has integrated your DualSense testing frontend. PeaSyo is a client application that truly applies the DualSense controller in practical use. Thank you very much for your project and inspiration!