### PR TITLE
feat: detect Ghost of Yotei (Z7) and Astro Bot Joyful (ZC) editions

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -97,10 +97,12 @@
         "god_of_war_ragnarok": "God of War Ragnarok",
         "spider_man_2": "Spider-Man 2",
         "astro_bot": "Astro Bot",
+        "astro_bot_joyful": "Astro Bot Joyful",
         "fortnite": "Fortnite",
         "the_last_of_us": "The Last of Us",
         "icon_blue_limited_edition": "Icon Blue Limited Edition",
-        "genshin_impact": "Genshin Impact"
+        "genshin_impact": "Genshin Impact",
+        "ghost_of_yotei": "Ghost of Yotei"
       },
       "assemble_parts_info": "Assemble Parts Info",
       "battery_barcode": "Battery Barcode",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -97,10 +97,12 @@
         "god_of_war_ragnarok": "战神：诸神黄昏",
         "spider_man_2": "漫威蜘蛛侠2",
         "astro_bot": "宇宙机器人",
+        "astro_bot_joyful": "宇宙机器人 欢乐版",
         "fortnite": "堡垒之夜",
         "the_last_of_us": "最后生还者",
         "icon_blue_limited_edition": "Icon Blue 特别版",
-        "genshin_impact": "原神"
+        "genshin_impact": "原神",
+        "ghost_of_yotei": "羊蹄山之魂"
       },
       "assemble_parts_info": "组装部件信息",
       "battery_barcode": "电池条码",

--- a/src/utils/dualsense/ds.type.ts
+++ b/src/utils/dualsense/ds.type.ts
@@ -439,6 +439,8 @@ export const DualSenseColorMap: Record<string, string> = {
   'Z3': 'astro_bot',
   'Z4': 'fortnite',
   'Z6': 'the_last_of_us',
+  'Z7': 'ghost_of_yotei',
   'ZB': 'icon_blue_limited_edition',
+  'ZC': 'astro_bot_joyful',
   'ZE': 'genshin_impact',
 }


### PR DESCRIPTION
## What

Add two limited-edition color codes to `DualSenseColorMap`, detected from serial-number chars 5–6 (`serial[4:6]`):

| Code | i18n key | English | 简体中文 |
|---|---|---|---|
| `Z7` | `ghost_of_yotei` | Ghost of Yotei | 羊蹄山之魂 |
| `ZC` | `astro_bot_joyful` | Astro Bot Joyful | 宇宙机器人 欢乐版 |

`ZC` is the *Joyful* variant, distinct from the existing `Z3` (`astro_bot`).

## Why

Both codes are corroborated by two independent issue reports each, and the official edition names were verified:

- `Z7` → [Ghost of Yōtei Limited Edition](https://www.playstation.com/en-us/ps5/ghost-of-yotei-limited-edition-ps5-bundle-and-accessories/) — reports #173, #181
- `ZC` → [ASTRO BOT Joyful Limited Edition](https://www.gamespot.com/articles/astro-bot-joyful-dualsense-limited-edition-ps5-controller-2025-preorder-guide/1100-6534678/) — reports #132, #177

Resolves the (already-closed) reports #132, #173, #177, #181.

## i18n note

Only `en-US.json` and `zh-CN.json` are touched. Chinese is set manually here on purpose — these are official product proper nouns that should not be machine/community-translated. Other locales are left to Crowdin.
