### PR TITLE
feat(edge): numeric editor for custom joystick curve points

### DIFF
--- a/src/components/common/JoystickCurveGraph.vue
+++ b/src/components/common/JoystickCurveGraph.vue
@@ -3,7 +3,8 @@ import type { FederatedPointerEvent } from 'pixi.js'
 import { useThrottleFn } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { Container, Graphics } from 'pixi.js'
-import { nextTick, onMounted, ref, shallowRef, useTemplateRef, watch } from 'vue'
+import { nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { setCurvePoint } from '@/router/DualSenseEdge/views/_Profile/profile'
 import { usePageStore } from '@/store/page'
 import { usePixiApp } from '@/utils/pixi.util'
 
@@ -18,6 +19,12 @@ const props = defineProps<{
 const emit = defineEmits<{
   updateCurve: [curve: number[]]
 }>()
+
+/**
+ * 当前激活(hover / 拖拽 / 与数值表联动)的控制点序号(0/1/2 对应 point1/2/3),无则为 null。
+ * 用 model 双向同步:图上交互写回父级,父级(数值表)也能反向高亮此处的点。
+ */
+const activePoint = defineModel<number | null>('activePoint', { default: null })
 
 const CanvasRef = useTemplateRef('CanvasRef')
 
@@ -35,8 +42,6 @@ onMounted(async () => {
     return
   }
 
-  const currentPoint = shallowRef<Graphics>()
-
   const grid = new Graphics()
   const deadzone = new Graphics()
   const defaultCurve = new Graphics()
@@ -44,17 +49,8 @@ onMounted(async () => {
   const activeCurve = new Graphics()
 
   function updateCurve(index: number, valueX: number, valueY: number) {
-    const newIndex = index + 1
-    const newCurve = [...props.curve]
-    // 取出第一个点
-    const firstPointX = newCurve[0]
-    const lastPointX = 255
-    const prevPointX = newCurve[(newIndex - 1) * 2] || firstPointX
-    const nextPointX = newCurve[(newIndex + 1) * 2] || lastPointX
-
-    newCurve[newIndex * 2] = Math.max(prevPointX, Math.min(nextPointX, valueX))
-    newCurve[newIndex * 2 + 1] = Math.max(0, Math.min(255, 255 - valueY))
-    emit('updateCurve', newCurve)
+    // valueX / valueY 为屏幕映射后的 0-255 值,Y 轴向下,故传入 255 - valueY 转为输出值空间
+    emit('updateCurve', setCurvePoint(props.curve, index + 1, valueX, 255 - valueY))
   }
   const dragPoints = new Container()
   const dragPointsChildren: Graphics[] = []
@@ -62,26 +58,28 @@ onMounted(async () => {
     const point = new Graphics()
     let isDragging = false
     function handlePointerEnter(this: Graphics, _e: FederatedPointerEvent) {
-      if (currentPoint.value) {
+      if (activePoint.value !== null) {
         return
       }
-      currentPoint.value = this
+      activePoint.value = i
     }
 
     function handlePointerLeave(this: Graphics, _e: FederatedPointerEvent) {
-      if (!isDragging) {
-        currentPoint.value = undefined
+      if (!isDragging && activePoint.value === i) {
+        activePoint.value = null
       }
     }
 
     function handlePointerDown(this: Graphics, _e: FederatedPointerEvent) {
       isDragging = true
-      currentPoint.value = this
+      activePoint.value = i
     }
 
     function handlePointerUp(this: Graphics, _e: FederatedPointerEvent) {
       isDragging = false
-      currentPoint.value = undefined
+      if (activePoint.value === i) {
+        activePoint.value = null
+      }
     }
 
     function handlePointerMove(this: Graphics, e: FederatedPointerEvent) {
@@ -232,7 +230,7 @@ onMounted(async () => {
       }
       else if (x + clipX > x + realCurve[realCurve.length - 2]) {
         const lastX = x + realCurve[realCurve.length - 2]
-        const lastY = y + realCurve[realCurve.length - 1]
+        const lastY = y + realCurve.at(-1)
 
         if (lastX < w) {
           const t = (clipX - lastX) / (w - lastX)
@@ -272,8 +270,9 @@ onMounted(async () => {
     for (let i = 2; i < realCurve.length; i += 2) {
       const x = realCurve[i]
       const y = realCurve[i + 1]
-      const point = dragPointsChildren[i / 2 - 1]
-      const isActive = currentPoint.value === point
+      const ordinal = i / 2 - 1
+      const point = dragPointsChildren[ordinal]
+      const isActive = activePoint.value === ordinal
       point.clear()
       point.setStrokeStyle({
         color: isActive ? colorPalette.value.active : colorPalette.value.primary,
@@ -285,7 +284,7 @@ onMounted(async () => {
         color: colorPalette.value.background,
         alpha: 1,
       })
-      point.circle(x, y, 6)
+      point.circle(x, y, isActive ? 8 : 6)
       point.fill()
       point.stroke()
     }
@@ -300,7 +299,7 @@ onMounted(async () => {
     current: 0,
     colorMode: '',
     editable: false,
-    currentPoint: undefined as any,
+    activePoint: null as number | null,
   }
 
   function draw() {
@@ -340,7 +339,7 @@ onMounted(async () => {
     }
 
     // 检查是否需要绘制操作点
-    if (basicChanged || prevContext.curve !== props.curve || prevContext.editable !== props.editable || currentPoint.value !== prevContext.currentPoint) {
+    if (basicChanged || prevContext.curve !== props.curve || prevContext.editable !== props.editable || activePoint.value !== prevContext.activePoint) {
       drawDragPoints(props.curve, width, height)
     }
 
@@ -353,7 +352,7 @@ onMounted(async () => {
       current: props.current,
       colorMode: pageStore.colorModeState,
       editable: props.editable || false,
-      currentPoint: currentPoint.value,
+      activePoint: activePoint.value,
     }
   }
 
@@ -364,7 +363,7 @@ onMounted(async () => {
   })
 
   watch(
-    () => [props.curve, props.defaultCurve, props.deadzone, props.current, props.editable, pageStore.colorModeState, currentPoint.value],
+    () => [props.curve, props.defaultCurve, props.deadzone, props.current, props.editable, pageStore.colorModeState, activePoint.value],
     () => {
       throttledDraw()
     },

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -97,10 +97,12 @@
         "god_of_war_ragnarok": "God of War Ragnarok",
         "spider_man_2": "Spider-Man 2",
         "astro_bot": "Astro Bot",
+        "astro_bot_joyful": "Astro Bot Joyful",
         "fortnite": "Fortnite",
         "the_last_of_us": "The Last of Us",
         "icon_blue_limited_edition": "Icon Blue Limited Edition",
-        "genshin_impact": "Genshin Impact"
+        "genshin_impact": "Genshin Impact",
+        "ghost_of_yotei": "Ghost of Yotei"
       },
       "assemble_parts_info": "Assemble Parts Info",
       "battery_barcode": "Battery Barcode",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -373,6 +373,18 @@
     "joystick_curves_adjust_label": "Curve adjustment",
     "joystick_deadzone_adjust_label": "Deadzone adjustment",
     "joystick_preview_raw_input": "Raw Input",
-    "joystick_preview_mapped_input": "Mapped Input"
+    "joystick_preview_mapped_input": "Mapped Input",
+    "joystick_curve_points": {
+      "label": "Control points",
+      "input": "Input",
+      "output": "Output",
+      "copy": "Copy curve",
+      "paste": "Paste curve",
+      "copied": "Curve copied to clipboard",
+      "copy_failed": "Failed to copy curve",
+      "pasted": "Curve pasted from clipboard",
+      "paste_invalid": "Clipboard does not contain a valid curve",
+      "paste_failed": "Failed to read clipboard"
+    }
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -373,6 +373,18 @@
     "joystick_curves_adjust_label": "曲线调整",
     "joystick_deadzone_adjust_label": "死区调整",
     "joystick_preview_raw_input": "原始输入",
-    "joystick_preview_mapped_input": "映射输入"
+    "joystick_preview_mapped_input": "映射输入",
+    "joystick_curve_points": {
+      "label": "控制点",
+      "input": "输入",
+      "output": "输出",
+      "copy": "复制曲线",
+      "paste": "粘贴曲线",
+      "copied": "曲线已复制到剪贴板",
+      "copy_failed": "复制曲线失败",
+      "pasted": "已从剪贴板粘贴曲线",
+      "paste_invalid": "剪贴板内容不是有效的曲线数据",
+      "paste_failed": "读取剪贴板失败"
+    }
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -97,10 +97,12 @@
         "god_of_war_ragnarok": "战神：诸神黄昏",
         "spider_man_2": "漫威蜘蛛侠2",
         "astro_bot": "宇宙机器人",
+        "astro_bot_joyful": "宇宙机器人 欢乐版",
         "fortnite": "堡垒之夜",
         "the_last_of_us": "最后生还者",
         "icon_blue_limited_edition": "Icon Blue 特别版",
-        "genshin_impact": "原神"
+        "genshin_impact": "原神",
+        "ghost_of_yotei": "羊蹄山之魂"
       },
       "assemble_parts_info": "组装部件信息",
       "battery_barcode": "电池条码",

--- a/src/router/DualSenseEdge/views/_Profile/pages/JoystickSensitivity/CurvePointsEditor.vue
+++ b/src/router/DualSenseEdge/views/_Profile/pages/JoystickSensitivity/CurvePointsEditor.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { Tooltip } from 'floating-vue'
+import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import DouNumberInput from '@/components/base/DouNumberInput.vue'
+import { useToast } from '@/composables/useToast'
+import { usePageStore } from '@/store/page'
+import { normalizeCurvePoints, setCurvePoint } from '../../profile'
+
+const props = defineProps<{
+  curve: number[]
+}>()
+
+const emit = defineEmits<{
+  updateCurve: [curve: number[]]
+}>()
+
+/**
+ * 与曲线图共享的激活点序号(0/1/2 对应 point1/2/3)。聚焦/悬停某行时写回,
+ * 让曲线图上对应的控制点同步高亮;曲线图上 hover/拖拽也会反向高亮此处的行。
+ */
+const activePoint = defineModel<number | null>('activePoint', { default: null })
+
+const { t } = useI18n()
+const toast = useToast()
+// 复用与曲线图相同的运行时调色板,使行高亮与图上激活点同色
+const { colorPalette } = storeToRefs(usePageStore())
+
+// 粘贴时按空白或逗号切分(提到模块作用域避免每次调用重新编译)
+const CURVE_SEPARATOR_RE = /[\s,]+/
+// 复制/粘贴提示的自动消失时长(ms),与项目其他 toast 保持一致
+const TOAST_DURATION = 3000
+
+// 3 个可编辑控制点(point1/2/3),point0 为死区点由"死区"滑块控制,不在此编辑
+const points = computed(() => {
+  return [0, 1, 2].map((ordinal) => {
+    const pointIndex = ordinal + 1
+    return {
+      ordinal,
+      pointIndex,
+      x: props.curve[pointIndex * 2],
+      y: props.curve[pointIndex * 2 + 1],
+      // X 受相邻点约束以保持单调不减
+      xMin: props.curve[(pointIndex - 1) * 2] ?? 0,
+      xMax: props.curve[(pointIndex + 1) * 2] ?? 255,
+    }
+  })
+})
+
+function updateX(pointIndex: number, x: number | undefined) {
+  if (x == null || Number.isNaN(x)) {
+    return
+  }
+  emit('updateCurve', setCurvePoint(props.curve, pointIndex, x, props.curve[pointIndex * 2 + 1]))
+}
+
+function updateY(pointIndex: number, y: number | undefined) {
+  if (y == null || Number.isNaN(y)) {
+    return
+  }
+  emit('updateCurve', setCurvePoint(props.curve, pointIndex, props.curve[pointIndex * 2], y))
+}
+
+function onRowBlur(e: FocusEvent, ordinal: number) {
+  // 焦点仍停留在本行内(在两个输入框间切换)时不清除高亮
+  const row = e.currentTarget as HTMLElement
+  if (row.contains(e.relatedTarget as Node | null)) {
+    return
+  }
+  if (activePoint.value === ordinal) {
+    activePoint.value = null
+  }
+}
+
+function onRowLeave(e: PointerEvent, ordinal: number) {
+  // 鼠标移出但焦点仍在本行(正在键盘输入)时保留高亮
+  const row = e.currentTarget as HTMLElement
+  if (row.contains(document.activeElement)) {
+    return
+  }
+  if (activePoint.value === ordinal) {
+    activePoint.value = null
+  }
+}
+
+async function copyCurve() {
+  try {
+    await navigator.clipboard.writeText(props.curve.join(', '))
+    toast.success({ content: t('profile_mode.joystick_curve_points.copied'), duration: TOAST_DURATION })
+  }
+  catch {
+    toast.error({ content: t('profile_mode.joystick_curve_points.copy_failed'), duration: TOAST_DURATION })
+  }
+}
+
+async function pasteCurve() {
+  let text: string
+  try {
+    text = await navigator.clipboard.readText()
+  }
+  catch {
+    toast.error({ content: t('profile_mode.joystick_curve_points.paste_failed'), duration: TOAST_DURATION })
+    return
+  }
+  const values = text.split(CURVE_SEPARATOR_RE).filter(Boolean).map(Number)
+  const normalized = normalizeCurvePoints(values)
+  if (!normalized) {
+    toast.error({ content: t('profile_mode.joystick_curve_points.paste_invalid'), duration: TOAST_DURATION })
+    return
+  }
+  emit('updateCurve', normalized)
+  toast.success({ content: t('profile_mode.joystick_curve_points.pasted'), duration: TOAST_DURATION })
+}
+</script>
+
+<template>
+  <div class="editor">
+    <div class="head">
+      <span class="title">{{ $t('profile_mode.joystick_curve_points.label') }}</span>
+      <div class="actions">
+        <Tooltip :delay="0">
+          <button type="button" class="action-btn" :aria-label="$t('profile_mode.joystick_curve_points.copy')" @click="copyCurve">
+            <div class="i-mingcute-copy-2-line" />
+          </button>
+          <template #popper>
+            {{ $t('profile_mode.joystick_curve_points.copy') }}
+          </template>
+        </Tooltip>
+        <Tooltip :delay="0">
+          <button type="button" class="action-btn" :aria-label="$t('profile_mode.joystick_curve_points.paste')" @click="pasteCurve">
+            <div class="i-mingcute-clipboard-line" />
+          </button>
+          <template #popper>
+            {{ $t('profile_mode.joystick_curve_points.paste') }}
+          </template>
+        </Tooltip>
+      </div>
+    </div>
+
+    <div class="columns">
+      <span class="badge-spacer" />
+      <span class="col-label">{{ $t('profile_mode.joystick_curve_points.input') }}</span>
+      <span class="col-label">{{ $t('profile_mode.joystick_curve_points.output') }}</span>
+    </div>
+
+    <div
+      v-for="p in points" :key="p.ordinal" class="point-row" :class="{ active: activePoint === p.ordinal }"
+      @pointerenter="activePoint = p.ordinal" @pointerleave="onRowLeave($event, p.ordinal)"
+      @focusin="activePoint = p.ordinal" @focusout="onRowBlur($event, p.ordinal)"
+    >
+      <span
+        class="badge"
+        :style="activePoint === p.ordinal ? { backgroundColor: colorPalette.active, color: '#fff' } : undefined"
+      >{{ p.ordinal + 1 }}</span>
+      <DouNumberInput
+        :model-value="p.x" :min="p.xMin" :max="p.xMax"
+        @update:model-value="updateX(p.pointIndex, $event)"
+      />
+      <DouNumberInput
+        :model-value="p.y" :min="0" :max="255"
+        @update:model-value="updateY(p.pointIndex, $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.editor {
+  @apply flex flex-col gap-2 w-full;
+}
+
+.head {
+  @apply flex items-center justify-between gap-2;
+
+  .title {
+    @apply text-sm text-primary font-bold select-none;
+  }
+
+  .actions {
+    @apply flex items-center gap-1;
+  }
+
+  .action-btn {
+    @apply flex items-center justify-center w-8 h-8 rounded-full text-primary dou-sc-colorborder;
+    @apply transition-colors hover:bg-stone-100 dark:hover:bg-stone-900;
+  }
+}
+
+.columns {
+  @apply grid items-center gap-2;
+  // minmax(0, 1fr) 允许轨道收缩到内容宽度以下,避免输入框固定宽撑出溢出
+  grid-template-columns: 1.5rem minmax(0, 1fr) minmax(0, 1fr);
+
+  .badge-spacer {
+    @apply w-6;
+  }
+
+  .col-label {
+    @apply text-xs text-primary opacity-70 text-center select-none;
+  }
+}
+
+.point-row {
+  @apply grid items-center gap-2 rounded-xl px-1 py-1 transition-colors;
+  grid-template-columns: 1.5rem minmax(0, 1fr) minmax(0, 1fr);
+
+  &.active {
+    @apply bg-stone-100 dark:bg-stone-900;
+  }
+
+  .badge {
+    @apply flex items-center justify-center w-6 h-6 rounded-full text-xs tabular-nums select-none;
+    @apply bg-primary/15 text-primary transition-colors;
+  }
+
+  // 让数值输入框填满单元格并可伸缩(覆盖共享组件里输入框的固定宽 w-20)
+  :deep(.number-input-wrapper) {
+    @apply w-full;
+  }
+
+  :deep(.number-input) {
+    @apply w-auto min-w-0 flex-1;
+  }
+}
+</style>

--- a/src/router/DualSenseEdge/views/_Profile/pages/JoystickSensitivity/JoystickPreview.vue
+++ b/src/router/DualSenseEdge/views/_Profile/pages/JoystickSensitivity/JoystickPreview.vue
@@ -11,6 +11,7 @@ import JoystickPreviewGraph from '@/components/common/JoystickPreviewGraph.vue'
 import SliderBox from '@/components/common/SliderBox.vue'
 import { usePageStore } from '@/store/page'
 import { DSEJoystickCurveMap, DSEJoystickCurvePos, DSEJoystickProfilePreset } from '../../profile'
+import CurvePointsEditor from './CurvePointsEditor.vue'
 
 defineProps<{
   current: number
@@ -83,7 +84,12 @@ const curveOptions = computed(() => [
 const adjustment = ref(0)
 const deadzone = ref(0)
 
+// 曲线图与数值表共享的激活控制点(0/1/2),实现两侧高亮联动
+const activePoint = ref<number | null>(null)
+
 const currentCurvePresetId = shallowRef(modelValue.value.preset)
+
+const isCustomCurve = computed(() => currentCurvePresetId.value === DSEJoystickProfilePreset.CUSTOM)
 
 const currentCurvePreset = computed(() => {
   return DSEJoystickCurveMap[currentCurvePresetId.value]
@@ -156,7 +162,7 @@ const throttleUpdateCurve = useThrottleFn(handleUpdateCurve, 16, true)
 </script>
 
 <template>
-  <div class="wrapper flex-col md:flex-row">
+  <div class="wrapper flex-col md:flex-row md:items-start">
     <div class="flex flex-col items-start gap-2">
       <div class="field">
         <label>{{ $t("profile_mode.joystick_curves_label") }}</label>
@@ -202,11 +208,20 @@ const throttleUpdateCurve = useThrottleFn(handleUpdateCurve, 16, true)
       </div>
     </div>
 
-    <JoystickCurveGraph
-      :default-curve="currentDefaultCurve" :current="current" :deadzone="deadzone / 100"
-      :curve="currentCurve" class="h-auto max-w-400px min-w-0 w-full flex-shrink"
-      :editable="currentCurvePresetId === DSEJoystickProfilePreset.CUSTOM" @update-curve="throttleUpdateCurve"
-    />
+    <div class="graph-col max-w-400px min-w-0 w-full flex flex-shrink flex-col gap-3">
+      <JoystickCurveGraph
+        v-model:active-point="activePoint"
+        :default-curve="currentDefaultCurve" :current="current" :deadzone="deadzone / 100"
+        :curve="currentCurve" class="h-auto w-full"
+        :editable="isCustomCurve" @update-curve="throttleUpdateCurve"
+      />
+      <CurvePointsEditor
+        v-if="isCustomCurve"
+        v-model:active-point="activePoint"
+        :curve="currentCurve"
+        @update-curve="handleUpdateCurve"
+      />
+    </div>
     <div class="min-w-0 w-full flex flex-shrink flex-grow">
       <JoystickPreviewGraph
         class="max-w-200px flex-shrink-0 flex-grow" :deadzone="deadzone / 100" :x="x" :y="y"

--- a/src/router/DualSenseEdge/views/_Profile/profile.ts
+++ b/src/router/DualSenseEdge/views/_Profile/profile.ts
@@ -376,6 +376,42 @@ export const DSEJoystickCurveMap: Record<DSEJoystickProfilePreset, DSEJoystickCu
   }),
 }
 
+/**
+ * 将曲线第 `pointIndex` 个点(1/2/3,point0 为死区点不在此处理)设为 (x, y),
+ * 并施加与拖拽完全一致的钳制:X 限制在 [前一点X, 后一点X](保持单调不减),Y 限制在 [0, 255]。
+ * 不修改入参,返回新的曲线数组。拖拽与数值输入共用此函数,确保两种交互行为一致。
+ */
+export function setCurvePoint(curve: number[], pointIndex: number, x: number, y: number): number[] {
+  const newCurve = [...curve]
+  const firstPointX = newCurve[0] ?? 0
+  const lastPointX = 255
+  const prevPointX = newCurve[(pointIndex - 1) * 2] ?? firstPointX
+  const nextPointX = newCurve[(pointIndex + 1) * 2] ?? lastPointX
+  newCurve[pointIndex * 2] = Math.round(Math.max(prevPointX, Math.min(nextPointX, x)))
+  newCurve[pointIndex * 2 + 1] = Math.round(Math.max(0, Math.min(255, y)))
+  return newCurve
+}
+
+/**
+ * 校验并规整一段粘贴进来的曲线数值:必须是 8 个有限数,逐项钳制到 [0, 255] 取整,
+ * 并强制 X(下标 0/2/4/6)单调不减。非法输入返回 null。
+ */
+export function normalizeCurvePoints(values: number[]): number[] | null {
+  if (!Array.isArray(values) || values.length !== 8) {
+    return null
+  }
+  if (values.some(v => typeof v !== 'number' || !Number.isFinite(v))) {
+    return null
+  }
+  const clamped = values.map(v => Math.round(Math.max(0, Math.min(255, v))))
+  for (let i = 2; i < 8; i += 2) {
+    if (clamped[i] < clamped[i - 2]) {
+      clamped[i] = clamped[i - 2]
+    }
+  }
+  return clamped
+}
+
 export enum DSEProfileButton {
   LB,
   RB,

--- a/src/utils/dualsense/ds.type.ts
+++ b/src/utils/dualsense/ds.type.ts
@@ -439,6 +439,8 @@ export const DualSenseColorMap: Record<string, string> = {
   'Z3': 'astro_bot',
   'Z4': 'fortnite',
   'Z6': 'the_last_of_us',
+  'Z7': 'ghost_of_yotei',
   'ZB': 'icon_blue_limited_edition',
+  'ZC': 'astro_bot_joyful',
   'ZE': 'genshin_impact',
 }


### PR DESCRIPTION
## What

Adds a numeric control-point editor under the DualSense Edge custom response curve, so points can be set by exact coordinates instead of only dragging with the mouse.

When the sensitivity curve is set to **Custom**, a compact table appears below the graph with the 3 editable control points (point0 is the deadzone, still driven by its slider). Each point has **Input (X)** and **Output (Y)** number fields on the raw `0–255` scale, with `+/-` steppers and keyboard arrows for fine adjustment.

- **Bidirectional highlight**: hovering/dragging a point on the graph highlights its row (and enlarges the dot); focusing a row highlights the matching point. Shared via a `v-model:active-point`.
- **Copy / Paste curve**: header buttons copy the 8 values as text and paste them back (validated + clamped + X kept monotonic), making it easy to move a curve between profiles. Toasts auto-dismiss after 3s.
- Drag and numeric input now share one clamp helper (`setCurvePoint`) so both behave identically; values are rounded to integers (matches what's written to the controller).

## Why

Requested in #172 (numeric values on the custom curve, like DSX) and #93 (mouse fine-adjustment is hard; wants per-point numbers that can be copied between profiles).

## Scale / units

Raw `0–255` (native hardware resolution → finest possible adjustment, integer, zero-loss to copy between profiles).

## i18n

`en-US.json` (source) and `zh-CN.json` updated; other locales left to Crowdin.

## Notes

- Two layout fixes included: preview graph was stretched into an ellipse (`md:items-start`), and the number inputs overflowed their column (`minmax(0, 1fr)` tracks + `:deep` flexible inputs).
- Verified with a production build; not hardware-tested (needs an Edge controller in Custom curve mode).
- The unrelated "don't turn the LED green on connect" ask in #172 is out of scope here.

Refs #172, #93
